### PR TITLE
Basic attach tests

### DIFF
--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -754,7 +754,11 @@ export class DartDebugSession extends DebugSession {
 				// dummy unconditional breakpoints.
 				// TODO: Ensure that VM breakpoint state is reconciled with debugger breakpoint state before
 				// handling thread state so that this doesn't happen, and remove this check.
-				const hasUnknownBreakpoints = breakpoints.includes(undefined);
+
+				// DT: This code doesn't compile for me (no includes?)
+				// const hasUnknownBreakpoints = breakpoints.includes(undefined);
+				const hasUnknownBreakpoints = breakpoints.indexOf(undefined) !== -1;
+
 				if (!hasUnknownBreakpoints) {
 					const hasUnconditionalBreakpoints = !!breakpoints.find((bp) => !bp.condition && !bp.logMessage);
 					const conditionalBreakpoints = breakpoints.filter((bp) => bp.condition);

--- a/test/dart_only/debug/dart_cli.test.ts
+++ b/test/dart_only/debug/dart_cli.test.ts
@@ -3,18 +3,20 @@ import * as path from "path";
 import * as vs from "vscode";
 import { DebugClient } from "vscode-debugadapter-testsupport";
 import { fsPath } from "../../../src/utils";
-import { ensureOutputContains, ensureVariable, evaluate, getTopFrameVariables, getVariables } from "../../debug_helpers";
-import { activate, closeAllOpenFiles, eol, ext, helloWorldBrokenFile, helloWorldFolder, helloWorldGoodbyeFile, helloWorldMainFile, openFile, positionOf } from "../../helpers";
+import { ensureOutputContains, ensureVariable, evaluate, getObservatoryUriForProcess, getTopFrameVariables, getVariables, spawnProcessPaused } from "../../debug_helpers";
+import { activate, closeAllOpenFiles, defer, eol, ext, helloWorldBrokenFile, helloWorldFolder, helloWorldGoodbyeFile, helloWorldMainFile, openFile, positionOf } from "../../helpers";
 
-describe("dart cli debugger", () => {
+describe.only("dart cli debugger", () => {
 	const dc = new DebugClient(process.execPath, path.join(ext.extensionPath, "out/src/debug/dart_debug_entry.js"), "dart");
 	dc.defaultTimeout = 30000;
 
 	beforeEach(() => activate(helloWorldMainFile));
 	afterEach(() => dc.stop());
 
-	async function startDebugger(script: vs.Uri): Promise<vs.DebugConfiguration> {
-		const config = await ext.exports.debugProvider.resolveDebugConfiguration(
+	// TODO: Combine this with the duplicates in other debugger tests (flutter run/flutter test) and
+	// move to helpers.ts
+	async function getLaunchConfig(script: vs.Uri): Promise<vs.DebugConfiguration> {
+		return await ext.exports.debugProvider.resolveDebugConfiguration(
 			vs.workspace.workspaceFolders[0],
 			{
 				name: "Dart & Flutter",
@@ -23,6 +25,29 @@ describe("dart cli debugger", () => {
 				type: "dart",
 			},
 		);
+	}
+
+	// TODO: move to helpers.ts
+	async function getAttachConfig(observatoryUri: string): Promise<vs.DebugConfiguration> {
+		return await ext.exports.debugProvider.resolveDebugConfiguration(
+			vs.workspace.workspaceFolders[0],
+			{
+				name: "Dart & Flutter",
+				observatoryUri,
+				request: "attach",
+				type: "dart",
+			},
+		);
+	}
+
+	async function startDebugger(script: vs.Uri): Promise<vs.DebugConfiguration> {
+		const config = await getLaunchConfig(script);
+		await dc.start(config.debugServer);
+		return config;
+	}
+
+	async function attachDebugger(observatoryUri: string): Promise<vs.DebugConfiguration> {
+		const config = await getAttachConfig(observatoryUri);
 		await dc.start(config.debugServer);
 		return config;
 	}
@@ -270,4 +295,40 @@ describe("dart cli debugger", () => {
 	});
 
 	it.skip("writes exception to stderr");
+
+	describe.only("attaches", () => {
+		it("to a paused Dart script and can unpause to run it to completion", async () => {
+			const process = spawnProcessPaused(await getLaunchConfig(helloWorldMainFile));
+			defer(() => process && !process.killed && process.kill());
+
+			const observatoryUri = await getObservatoryUriForProcess(process);
+
+			const config = await attachDebugger(observatoryUri);
+			await Promise.all([
+				dc.configurationSequence(),
+				dc.waitForEvent("terminated"),
+				dc.launch(config),
+			]);
+		});
+
+		it("to a paused Dart script and can set breakpoints", async () => {
+			const process = spawnProcessPaused(await getLaunchConfig(helloWorldMainFile));
+			defer(() => process && !process.killed && process.kill());
+
+			const observatoryUri = await getObservatoryUriForProcess(process);
+
+			const config = await attachDebugger(observatoryUri);
+			await Promise.all([
+				dc.hitBreakpoint(config, {
+					line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
+					path: fsPath(helloWorldMainFile),
+				}),
+			]);
+		});
+
+		it("when provided only a port in launch.config");
+		// This one will need to wrap showInputBox with sinon (similar to extract_widget.test.ts)
+		it("to the observatory uri provided by the user when not specified in launch.json");
+		it("and removes breakpoints and unpauses on detach");
+	});
 });

--- a/test/dart_only/debug/dart_cli.test.ts
+++ b/test/dart_only/debug/dart_cli.test.ts
@@ -6,7 +6,7 @@ import { fsPath } from "../../../src/utils";
 import { ensureOutputContains, ensureVariable, evaluate, getObservatoryUriForProcess, getTopFrameVariables, getVariables, spawnProcessPaused } from "../../debug_helpers";
 import { activate, closeAllOpenFiles, defer, eol, ext, helloWorldBrokenFile, helloWorldFolder, helloWorldGoodbyeFile, helloWorldMainFile, openFile, positionOf } from "../../helpers";
 
-describe.only("dart cli debugger", () => {
+describe("dart cli debugger", () => {
 	const dc = new DebugClient(process.execPath, path.join(ext.extensionPath, "out/src/debug/dart_debug_entry.js"), "dart");
 	dc.defaultTimeout = 30000;
 
@@ -296,7 +296,7 @@ describe.only("dart cli debugger", () => {
 
 	it.skip("writes exception to stderr");
 
-	describe.only("attaches", () => {
+	describe("attaches", () => {
 		it("to a paused Dart script and can unpause to run it to completion", async () => {
 			const process = spawnProcessPaused(await getLaunchConfig(helloWorldMainFile));
 			defer(() => process && !process.killed && process.kill());

--- a/test/debug_helpers.ts
+++ b/test/debug_helpers.ts
@@ -1,7 +1,11 @@
 import * as assert from "assert";
+import { ChildProcess } from "child_process";
+import { DebugConfiguration } from "vscode";
 import { Variable } from "vscode-debugadapter";
 import { DebugClient } from "vscode-debugadapter-testsupport";
 import { DebugProtocol } from "vscode-debugprotocol";
+import { ObservatoryConnection } from "../src/debug/dart_debug_protocol";
+import { safeSpawn } from "../src/debug/utils";
 
 export async function getTopFrameVariables(dc: DebugClient, scope: "Exception" | "Locals"): Promise<Variable[]> {
 	const threads = await dc.threadsRequest();
@@ -53,4 +57,26 @@ export function ensureOutputContains(dc: DebugClient, category: string, text: st
 				reject(new Error(`Didn't find text "${text}" in ${category}`));
 		}
 	}));
+}
+
+export function spawnProcessPaused(config: DebugConfiguration) {
+	return safeSpawn(
+		config.cwd,
+		config.dartPath,
+		[
+			"--enable-vm-service=0",
+			"-pause_isolates_on_start=true",
+			config.program,
+		],
+	);
+}
+
+export function getObservatoryUriForProcess(process: ChildProcess): Promise<string> {
+	return new Promise((resolve, reject) => {
+		process.stdout.on("data", (data) => {
+			const match = ObservatoryConnection.portRegex.exec(data.toString());
+			if (match)
+				resolve(match[1]);
+		});
+	});
 }


### PR DESCRIPTION
I added some very basic tests for attach. They spawn one of the test scripts paused, attach and then ensure that it runs to completion and/or hits a breakpoint. They both immediately passed which always makes me nervous but when I fudged the breakpoint line numbers, that one failed as I'd expect so I think they are working as expected.

I also added a couple of unimplemented tests we might want to add.

You may also want to review the change I made to get it compiling, I had an error that `.includes()` didn't exist on an array (I changed it to `indexOf() !== -1`).